### PR TITLE
Fix links to marked

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # gulp-markdown [![Build Status](https://travis-ci.org/sindresorhus/gulp-markdown.svg?branch=master)](https://travis-ci.org/sindresorhus/gulp-markdown)
 
-> Markdown to HTML with [`marked`](https://github.com/chjj/marked)
+> Markdown to HTML with [`marked`](https://github.com/markedjs/marked)
 
-*Issues with the output should be reported on the `marked` [issue tracker](https://github.com/chjj/marked/issues).*
+*Issues with the output should be reported on the `marked` [issue tracker](https://github.com/markedjs/marked/issues).*
 
 
 ## Install
@@ -30,11 +30,11 @@ gulp.task('default', () =>
 
 ### markdown([options])
 
-See the `marked` [options](https://github.com/chjj/marked#options-1).
+See the `marked` [options](https://marked.js.org/#/USING_ADVANCED.md).
 
 ### markdown.marked
 
-Access the `marked` object to customize the [lexer](https://github.com/chjj/marked#access-to-lexer-and-parser), [parser](https://github.com/chjj/marked#access-to-lexer-and-parser) or [renderer](https://github.com/chjj/marked#renderer).
+Access the `marked` object to customize the [lexer](https://marked.js.org/#/USING_PRO.md#lexer), [parser](https://marked.js.org/#/USING_PRO.md#parser) or [renderer](https://marked.js.org/#/USING_PRO.md#renderer).
 
 
 ## License


### PR DESCRIPTION
Some of the docs have moved and there is now a markedjs org on GitHub