### PR TITLE
Allow customization of the `marked` renderer

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,10 @@ const through = require('through2');
 const marked = require('marked');
 const PluginError = require('plugin-error');
 
-const pMarked = promisify(marked);
-
 module.exports = options => {
+	marked.use(options);
+	const pMarked = promisify(marked);
+	
 	return through.obj(async (file, encoding, callback) => {
 		if (file.isNull()) {
 			callback(null, file);
@@ -19,7 +20,7 @@ module.exports = options => {
 		}
 
 		try {
-			const data = await pMarked(file.contents.toString(), options);
+			const data = await pMarked(file.contents.toString());
 			file.contents = Buffer.from(data);
 			file.extname = '.html';
 			callback(null, file);

--- a/index.js
+++ b/index.js
@@ -5,7 +5,10 @@ const marked = require('marked');
 const PluginError = require('plugin-error');
 
 module.exports = options => {
-	marked.use(options);
+	if (options) {
+		marked.use(options);
+	}
+
 	const pMarked = promisify(marked);
 
 	return through.obj(async (file, encoding, callback) => {

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const PluginError = require('plugin-error');
 module.exports = options => {
 	marked.use(options);
 	const pMarked = promisify(marked);
-	
+
 	return through.obj(async (file, encoding, callback) => {
 		if (file.isNull()) {
 			callback(null, file);

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
 		"html"
 	],
 	"dependencies": {
-		"marked": "^0.7.0",
+		"marked": "^1.1.0",
 		"plugin-error": "^1.0.1",
-		"through2": "^3.0.1"
+		"through2": "^4.0.2"
 	},
 	"devDependencies": {
 		"ava": "^2.3.0",


### PR DESCRIPTION
- See https://marked.js.org/#/USING_PRO.md#renderer for syntax
- Initialize options only once for each gulp task to speed up performance
- Update package.json dependencies